### PR TITLE
Feature:  Implementação da APIService, Service Error, Router e testes unitários

### DIFF
--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		18C4813E27A05509000BF262 /* ServiceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4813D27A05509000BF262 /* ServiceManagerTests.swift */; };
+		18C4814927A0698F000BF262 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814827A0698F000BF262 /* URLProtocolMock.swift */; };
+		18C4814B27A098E7000BF262 /* DeliveryApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */; };
+		18DC4613279F6176001911D6 /* ServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC4612279F6176001911D6 /* ServiceError.swift */; };
+		18DC4617279F71A4001911D6 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC4616279F71A4001911D6 /* APIService.swift */; };
+		18DC4619279F85D3001911D6 /* RestaurantsListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */; };
+		18DC461C279FA210001911D6 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC461B279FA210001911D6 /* Router.swift */; };
 		983271BD272752AF0010C63A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271BC272752AF0010C63A /* AppDelegate.swift */; };
 		983271BF272752AF0010C63A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271BE272752AF0010C63A /* SceneDelegate.swift */; };
 		983271C1272752AF0010C63A /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271C0272752AF0010C63A /* HomeViewController.swift */; };
@@ -47,6 +54,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		18C4813D27A05509000BF262 /* ServiceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceManagerTests.swift; sourceTree = "<group>"; };
+		18C4814827A0698F000BF262 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
+		18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryApiTests.swift; sourceTree = "<group>"; };
+		18DC4612279F6176001911D6 /* ServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceError.swift; sourceTree = "<group>"; };
+		18DC4616279F71A4001911D6 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
+		18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestaurantsListModel.swift; path = DeliveryAppChallenge/Models/RestaurantsListModel.swift; sourceTree = SOURCE_ROOT; };
+		18DC461B279FA210001911D6 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		983271B9272752AF0010C63A /* DeliveryAppChallenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DeliveryAppChallenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		983271BC272752AF0010C63A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		983271BE272752AF0010C63A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -97,6 +111,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		18C4814127A0578C000BF262 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				18C4814827A0698F000BF262 /* URLProtocolMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		983271B0272752AF0010C63A = {
 			isa = PBXGroup;
 			children = (
@@ -131,7 +153,10 @@
 		983271D2272752B50010C63A /* DeliveryAppChallengeTests */ = {
 			isa = PBXGroup;
 			children = (
+				18C4814127A0578C000BF262 /* Mocks */,
 				983271D3272752B50010C63A /* DeliveryAppChallengeTests.swift */,
+				18C4813D27A05509000BF262 /* ServiceManagerTests.swift */,
+				18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */,
 			);
 			path = DeliveryAppChallengeTests;
 			sourceTree = "<group>";
@@ -173,6 +198,9 @@
 			isa = PBXGroup;
 			children = (
 				98EA0565272A0A0F007B0228 /* DeliveryApi.swift */,
+				18DC461B279FA210001911D6 /* Router.swift */,
+				18DC4612279F6176001911D6 /* ServiceError.swift */,
+				18DC4616279F71A4001911D6 /* APIService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -180,6 +208,7 @@
 		983271F0272753000010C63A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -425,12 +454,16 @@
 				98FC5AAE2732BA2E002412EA /* RestaurantInfoView.swift in Sources */,
 				98612707272F56AB0049403C /* SettingsView.swift in Sources */,
 				98F1297D272F51DE00B88A87 /* MenuItemViewController.swift in Sources */,
+				18DC4617279F71A4001911D6 /* APIService.swift in Sources */,
+				18DC4613279F6176001911D6 /* ServiceError.swift in Sources */,
 				98FC5AB12732BB7D002412EA /* RatingView.swift in Sources */,
 				98EA055B272A092F007B0228 /* AddressSearchViewController.swift in Sources */,
+				18DC4619279F85D3001911D6 /* RestaurantsListModel.swift in Sources */,
 				98EA0566272A0A0F007B0228 /* DeliveryApi.swift in Sources */,
 				98612707272F56AB0049403C /* SettingsView.swift in Sources */,
 				98F1297D272F51DE00B88A87 /* MenuItemViewController.swift in Sources */,
 				98F12975272F48E400B88A87 /* AddressCellView.swift in Sources */,
+				18DC461C279FA210001911D6 /* Router.swift in Sources */,
 				98F12970272F41AE00B88A87 /* RestaurantCellView.swift in Sources */,
 				98F12977272F48F000B88A87 /* AddressListView.swift in Sources */,
 				98EA055E272A0949007B0228 /* RestaurantListViewController.swift in Sources */,
@@ -455,7 +488,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18C4814927A0698F000BF262 /* URLProtocolMock.swift in Sources */,
 				983271D4272752B50010C63A /* DeliveryAppChallengeTests.swift in Sources */,
+				18C4814B27A098E7000BF262 /* DeliveryApiTests.swift in Sources */,
+				18C4813E27A05509000BF262 /* ServiceManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/xcshareddata/xcschemes/DeliveryAppChallenge.xcscheme
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/xcshareddata/xcschemes/DeliveryAppChallenge.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/RestaurantsListModel.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/RestaurantsListModel.swift
@@ -1,0 +1,24 @@
+//
+//  RestaurantsListModel.swift
+//  DeliveryAppChallenge
+//
+//  Created by Alley Pereira on 24/01/22.
+//
+
+import Foundation
+
+struct RestaurantsListModel: Codable {
+	let name: String
+	let category: String
+	let deliveryTime: DeliveryTime
+
+	struct DeliveryTime: Codable {
+		let min: Int
+		let max: Int
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case name, category
+		case deliveryTime = "delivery_time"
+	}
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/APIService.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/APIService.swift
@@ -1,0 +1,57 @@
+//
+//  APIService.swift
+//  DeliveryAppChallenge
+//
+//  Created by Alley Pereira on 24/01/22.
+//
+
+import Foundation
+
+// MARK: Protocol
+protocol APIServiceProtocol {
+
+	var session: URLSession { get }
+
+	func get<T:Decodable>(
+		request: URLRequest,
+		of type: T.Type,
+		completion: @escaping(Result<T, ServiceError>) -> Void
+	)
+}
+
+// MARK: Implementation
+final class APIService: APIServiceProtocol {
+
+	let session: URLSession
+
+	init(_ session: URLSession = .shared) {
+		self.session = session
+	}
+
+	func get<T: Decodable>(
+		request: URLRequest,
+		of type: T.Type,
+		completion: @escaping (Result<T, ServiceError>) -> Void
+	) {
+		session.dataTask(with: request) { data, response, error in
+			do {
+				if let error = error {
+					completion(.failure(.requestFailed(description: error.localizedDescription)))
+					return
+				}
+
+				guard let data = data, !data.isEmpty else {
+					completion(.failure(.emptyData))
+					return
+				}
+
+				let json = try JSONDecoder().decode(T.self, from: data)
+				completion(.success(json))
+
+			} catch {
+				print("❌ Decode error", error)
+				completion(.failure(.decodeError))
+			}
+		}.resume()
+	}
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/APIService.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/APIService.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// MARK: Protocol
 protocol APIServiceProtocol {
 
 	var session: URLSession { get }
@@ -19,7 +18,6 @@ protocol APIServiceProtocol {
 	)
 }
 
-// MARK: Implementation
 final class APIService: APIServiceProtocol {
 
 	let session: URLSession

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
@@ -9,9 +9,33 @@ import Foundation
 
 struct DeliveryApi {
 
-    func fetchRestaurants(_ completion: ([String]) -> Void) {
+	var serviceManager: APIServiceProtocol = APIService()
 
-        completion(["Restaurant 1", "Restaurant 2", "Restaurant 3"])
+	/**
+	 Fetch restaurants from API.
+
+	 - Parameters:
+	   - completion: a callback to receive the `[RestaurantListModel]` array.
+
+	 Usage:
+	 ```
+	 let api = DeliveryApi()
+
+	 api.fetchRestaurants { restaurants in
+	   // do what you want with the restaurants array
+	 }
+	 ```
+	*/
+    func fetchRestaurants(_ completion: @escaping ([RestaurantsListModel]) -> Void) {
+		serviceManager.get(request: Router.fetchRestaurants.getRequest,
+						   of: [RestaurantsListModel].self) { result in
+			switch result {
+			case .success(let restaurantList):
+				completion(restaurantList)
+			case .failure:
+				completion([])
+			}
+		}
     }
 
     func searchAddresses(_ completion: ([String]) -> Void) {

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
@@ -1,0 +1,40 @@
+//
+//  Router.swift
+//  DeliveryAppChallenge
+//
+//  Created by Alley Pereira on 25/01/22.
+//
+
+import Foundation
+
+enum Router {
+
+	/// Create new cases for more requests
+	case fetchRestaurants
+	case fetchRestaurantDetails
+	case fetchMenuItem
+
+	static private let baseURL: String = "https://raw.githubusercontent.com/devpass-tech/challenge-delivery-app/main/api"
+
+	var url: URL {
+		URL(string: Self.baseURL+self.path)!
+	}
+
+	var path: String {
+		switch self {
+		case .fetchRestaurants:
+			return "/home_restaurant_list.json"
+		case .fetchRestaurantDetails:
+			return ""
+		case .fetchMenuItem:
+			return ""
+		}
+	}
+
+	var getRequest: URLRequest {
+		var request = URLRequest(url: self.url)
+		request.httpMethod = "GET"
+		return request
+	}
+
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/ServiceError.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/ServiceError.swift
@@ -1,0 +1,25 @@
+//
+//  ServiceError.swift
+//  DeliveryAppChallenge
+//
+//  Created by Alley Pereira on 24/01/22.
+//
+
+import Foundation
+
+enum ServiceError: Error {
+    case requestFailed(description: String)
+	case emptyData
+    case decodeError
+
+	var localizedDescription: String {
+		switch self {
+		case .emptyData:
+			return "No error was received but we also don't have data."
+		case .requestFailed(description: let description):
+			return "Could not run request because: \(description)"
+		case .decodeError:
+			return "Could not decoded result"
+		}
+	}
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
@@ -5,4 +5,57 @@
 //  Created by Alley Pereira on 25/01/22.
 //
 
-import Foundation
+import XCTest
+@testable import DeliveryAppChallenge
+
+
+class DeliveryApiTests: XCTestCase {
+
+	// MARK: Subject under test
+	var sut: DeliveryApi!
+
+	class APIServiceSpy: APIServiceProtocol {
+
+		var session: URLSession = {
+			URLProtocolMock.mockSession(
+				with: Router.fetchRestaurants.getRequest,
+				completionMock: (nil,nil,nil)
+			)
+		}()
+
+		var getCalled: Bool = false
+
+		func get<T>(request: URLRequest, of type: T.Type, completion: @escaping (Result<T, ServiceError>) -> Void) where T : Decodable {
+			getCalled = true
+		}
+	}
+
+	// MARK: Test setup
+	override func setUp() {
+		super.setUp()
+		self.sut = DeliveryApi()
+	}
+
+	override func tearDown() {
+		super.tearDown()
+		self.sut = nil
+	}
+
+	func test_fetchRestaurants_apiManagerCallsGet() {
+		// Given
+		let spy = APIServiceSpy()
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurants { _ in
+			
+		// Then
+			XCTAssertTrue(spy.getCalled)
+		}
+	}
+
+	private func encode(_ dataMock: [RestaurantsListModel]) -> Data {
+		try! JSONEncoder().encode(dataMock)
+	}
+
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
@@ -1,0 +1,8 @@
+//
+//  DeliveryApiTests.swift
+//  DeliveryAppChallengeTests
+//
+//  Created by Alley Pereira on 25/01/22.
+//
+
+import Foundation

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Mocks/URLProtocolMock.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Mocks/URLProtocolMock.swift
@@ -1,0 +1,8 @@
+//
+//  URLProtocolMock.swift
+//  DeliveryAppChallengeTests
+//
+//  Created by Alley Pereira on 25/01/22.
+//
+
+import Foundation

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Mocks/URLProtocolMock.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Mocks/URLProtocolMock.swift
@@ -6,3 +6,62 @@
 //
 
 import Foundation
+
+class URLProtocolMock: URLProtocol {
+
+	typealias RequestCompletion = (data: Data?, response: HTTPURLResponse?, error: Error?)
+
+	/// Dictionary maps URLs to tuples of error, data, and response
+	static var urlRequests = [URLRequest: RequestCompletion]()
+
+	static func mockSession(with request: URLRequest, completionMock: RequestCompletion) -> URLSession {
+
+		urlRequests = [
+			request: completionMock
+		]
+
+		let sessionConfiguration = URLSessionConfiguration.ephemeral
+		sessionConfiguration.protocolClasses = [URLProtocolMock.self]
+
+		let mockSession = URLSession(configuration: sessionConfiguration)
+
+		return mockSession
+	}
+
+	override class func canInit(with request: URLRequest) -> Bool {
+		// Handle all types of requests
+		return true
+	}
+
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+		// Required to be implemented here. Just return what is passed
+		return request
+	}
+
+	override func startLoading() {
+
+		let completion = URLProtocolMock.urlRequests[request]
+
+		// We have a mock response specified so return it.
+		if let responseStrong = completion?.response {
+			self.client?.urlProtocol(self, didReceive: responseStrong, cacheStoragePolicy: .notAllowed)
+		}
+
+		// We have mocked data specified so return it.
+		if let dataStrong = completion?.data, dataStrong != "null".data(using: .utf8) {
+			self.client?.urlProtocol(self, didLoad: dataStrong)
+		}
+
+		// We have a mocked error so return it.
+		if let errorStrong = completion?.error {
+			self.client?.urlProtocol(self, didFailWithError: errorStrong)
+		}
+
+		// Send the signal that we are done returning our mock response
+		self.client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {
+		// Required to be implemented. Do nothing here.
+	}
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
@@ -25,7 +25,7 @@ class ServiceManagerTests: XCTestCase {
 		URLProtocolMock.urlRequests.removeAll()
 	}
 
-	func test_getRestaurants_shouldReturnsSuccess() {
+	func test_get_whenFetchRestaurants_shouldReturnSuccess() {
 		// Given
 		let endpoint = Router.fetchRestaurants
 		let dataMock = dataMock()
@@ -106,7 +106,7 @@ class ServiceManagerTests: XCTestCase {
 		wait(for: [expectation], timeout: 1)
 	}
 
-	func test_get_error_failure() {
+	func test_whenErrorFetch_shouldReturnFailure() {
 		// Given
 		let endpoint = Router.fetchRestaurants
 		let expectedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
@@ -1,0 +1,32 @@
+//
+//  ServiceManagerTests.swift
+//  DeliveryAppChallengeTests
+//
+//  Created by Alley Pereira on 25/01/22.
+//
+
+import XCTest
+
+class ServiceManagerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
@@ -6,27 +6,205 @@
 //
 
 import XCTest
+@testable import DeliveryAppChallenge
 
 class ServiceManagerTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+	// MARK: Subject under test
+	var sut: APIService!
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+	// MARK: Test setup
+	override func setUp() {
+		super.setUp()
+		self.sut = APIService()
+	}
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+	override func tearDown() {
+		super.tearDown()
+		self.sut = nil
+		URLProtocolMock.urlRequests.removeAll()
+	}
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+	func test_get_restaurants_success() {
+		// Given
+		let endpoint = Router.fetchRestaurants
+		let dataMock = dataMock()
+		let successCompletion = createResquestCompletionMock(
+			endpoint: endpoint,
+			dataMock: dataMock,
+			statusCode: 200,
+			error: nil
+		)
+		let mockSession = URLProtocolMock.mockSession(
+			with: endpoint.getRequest,
+			completionMock: successCompletion
+		)
+		self.sut = APIService(mockSession)
+
+		let expectation = expectation(description: "success")
+
+		// When
+		sut.get(
+			request: endpoint.getRequest,
+			of: [RestaurantsListModel].self,
+			completion: { result in
+				// Then
+				switch result {
+				case .failure:
+					XCTFail()
+				case .success(let model):
+					expectation.fulfill()
+					XCTAssertFalse(model.isEmpty)
+					if let first = try? XCTUnwrap(model.first) {
+						XCTAssertEqual(first.name, dataMock[0].name)
+						XCTAssertEqual(first.category, dataMock[0].category)
+						XCTAssertEqual(first.deliveryTime.min, dataMock[0].deliveryTime.min)
+						XCTAssertEqual(first.deliveryTime.max, dataMock[0].deliveryTime.max)
+					} else {
+						XCTFail()
+					}
+				}
+				
+			}
+		)
+
+		wait(for: [expectation], timeout: 2)
+	}
+
+	func test_get_emptyData_failure() {
+		// Given
+		let endpoint = Router.fetchRestaurants
+		let successCompletion: URLProtocolMock.RequestCompletion = (
+			nil,
+			nil,
+			nil
+		)
+		let mockSession = URLProtocolMock.mockSession(
+			with: endpoint.getRequest,
+			completionMock: successCompletion
+		)
+		self.sut = APIService(mockSession)
+
+		let expectation = expectation(description: "failure")
+
+		// When
+		sut.get(
+			request: endpoint.getRequest,
+			of: [RestaurantsListModel].self,
+			completion: { result in
+				// Then
+				switch result {
+				case .failure(let error):
+					expectation.fulfill()
+					XCTAssertEqual(error.localizedDescription, ServiceError.emptyData.localizedDescription)
+				case .success:
+					XCTFail()
+				}
+			}
+		)
+
+		wait(for: [expectation], timeout: 2)
+	}
+
+	func test_get_error_failure() {
+		// Given
+		let endpoint = Router.fetchRestaurants
+		let expectedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+		let successCompletion: URLProtocolMock.RequestCompletion = (
+			nil,
+			nil,
+			expectedError
+		)
+		let mockSession = URLProtocolMock.mockSession(
+			with: endpoint.getRequest,
+			completionMock: successCompletion
+		)
+		self.sut = APIService(mockSession)
+
+		let expectation = expectation(description: "failure")
+
+		// When
+		sut.get(
+			request: endpoint.getRequest,
+			of: [RestaurantsListModel].self,
+			completion: { result in
+				// Then
+				switch result {
+				case .failure(let error):
+					expectation.fulfill()
+					XCTAssertEqual(error.localizedDescription, ServiceError.requestFailed(description: expectedError.localizedDescription).localizedDescription)
+				case .success:
+					XCTFail()
+				}
+			}
+		)
+
+		wait(for: [expectation], timeout: 2)
+	}
+
+	func test_get_decodeError_failure() {
+		// Given
+		let endpoint = Router.fetchRestaurants
+		let successCompletion: URLProtocolMock.RequestCompletion = (
+			"{\"key\": \"value\"}".data(using: .utf8),
+			nil,
+			nil
+		)
+		let mockSession = URLProtocolMock.mockSession(
+			with: endpoint.getRequest,
+			completionMock: successCompletion
+		)
+		self.sut = APIService(mockSession)
+
+		let expectation = expectation(description: "failure")
+
+		// When
+		sut.get(
+			request: endpoint.getRequest,
+			of: [RestaurantsListModel].self,
+			completion: { result in
+				// Then
+				switch result {
+				case .failure(let error):
+					expectation.fulfill()
+					XCTAssertEqual(error.localizedDescription, ServiceError.decodeError.localizedDescription)
+				case .success:
+					XCTFail()
+				}
+			}
+		)
+
+		wait(for: [expectation], timeout: 2)
+	}
+
+
+
+	// MARK: - Mocks
+	private func createResquestCompletionMock<T: Codable>(
+		endpoint: Router,
+		dataMock: T,
+		statusCode: Int,
+		error: Error? = nil
+	) -> URLProtocolMock.RequestCompletion {
+		let data = try? JSONEncoder().encode(dataMock)
+		let response = HTTPURLResponse(
+			url: endpoint.url,
+			statusCode: statusCode,
+			httpVersion: nil,
+			headerFields: nil
+		)
+		return (data, response, error)
+	}
+
+	private func dataMock() -> [RestaurantsListModel] {
+		let dataMock: [RestaurantsListModel] = [
+			RestaurantsListModel(
+				name: "Benjamin a Padaria",
+				category: "Padaria",
+				deliveryTime: .init(min: 10, max: 45)
+			)
+		]
+		return dataMock
+	}
 
 }

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
@@ -25,7 +25,7 @@ class ServiceManagerTests: XCTestCase {
 		URLProtocolMock.urlRequests.removeAll()
 	}
 
-	func test_get_restaurants_success() {
+	func test_getRestaurants_shouldReturnsSuccess() {
 		// Given
 		let endpoint = Router.fetchRestaurants
 		let dataMock = dataMock()
@@ -68,10 +68,10 @@ class ServiceManagerTests: XCTestCase {
 			}
 		)
 
-		wait(for: [expectation], timeout: 2)
+		wait(for: [expectation], timeout: 1)
 	}
 
-	func test_get_emptyData_failure() {
+	func test_get_whenEmptyData_shouldReturnFailure() {
 		// Given
 		let endpoint = Router.fetchRestaurants
 		let successCompletion: URLProtocolMock.RequestCompletion = (
@@ -103,7 +103,7 @@ class ServiceManagerTests: XCTestCase {
 			}
 		)
 
-		wait(for: [expectation], timeout: 2)
+		wait(for: [expectation], timeout: 1)
 	}
 
 	func test_get_error_failure() {
@@ -139,10 +139,10 @@ class ServiceManagerTests: XCTestCase {
 			}
 		)
 
-		wait(for: [expectation], timeout: 2)
+		wait(for: [expectation], timeout: 1)
 	}
 
-	func test_get_decodeError_failure() {
+	func test_get_whenDecodeError_shouldReturnFailure() {
 		// Given
 		let endpoint = Router.fetchRestaurants
 		let successCompletion: URLProtocolMock.RequestCompletion = (
@@ -174,7 +174,7 @@ class ServiceManagerTests: XCTestCase {
 			}
 		)
 
-		wait(for: [expectation], timeout: 2)
+		wait(for: [expectation], timeout: 1)
 	}
 
 


### PR DESCRIPTION
Implementação da:
-  APIService de forma genérica para reutilização da mesma
- Camada de ServiceError 
- Router para implementação das rotas da API

**Como utilizar o Route para outras implementações?**

Criar mais cases correspondentes a cada rota

<img width="383" alt="Captura de Tela 2022-01-25 às 20 11 24" src="https://user-images.githubusercontent.com/29764688/151075284-35086c8b-b8b6-49af-a0cc-5909c1eedd56.png">

Colocar a rota que será utilizada

<img width="491" alt="Captura de Tela 2022-01-25 às 20 12 17" src="https://user-images.githubusercontent.com/29764688/151075345-23248c73-3d20-450d-9357-6fea4e2a280c.png">

