### PR TITLE
Implementar integração com DeliveryAPI para busca de endereços

### DIFF
--- a/solutions/devsprint-vinicius-carvalho-1/Address.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/Address.swift
@@ -1,0 +1,15 @@
+//
+//  Address.swift
+//  DeliveryAppChallenge
+//
+//  Created by Rodrigo Lemos on 25/01/22.
+//
+
+import Foundation
+
+struct Address: Decodable {
+    
+    let street: String
+    let number: String
+    let neighborhood: String
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		98FC5AB42732BFC8002412EA /* MenuListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB32732BFC8002412EA /* MenuListView.swift */; };
 		98FC5AB62732BFDA002412EA /* MenuCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB52732BFDA002412EA /* MenuCellView.swift */; };
 		98FC5AB82732C1EF002412EA /* MenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB72732C1EF002412EA /* MenuItemView.swift */; };
+		B72496F627A0AEFC00244D5C /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72496F527A0AEFC00244D5C /* Address.swift */; };
+		B72496F927A0BD0B00244D5C /* DeliveryApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72496F827A0BD0B00244D5C /* DeliveryApiTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +79,8 @@
 		98FC5AB32732BFC8002412EA /* MenuListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListView.swift; sourceTree = "<group>"; };
 		98FC5AB52732BFDA002412EA /* MenuCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCellView.swift; sourceTree = "<group>"; };
 		98FC5AB72732C1EF002412EA /* MenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemView.swift; sourceTree = "<group>"; };
+		B72496F527A0AEFC00244D5C /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = SOURCE_ROOT; };
+		B72496F827A0BD0B00244D5C /* DeliveryApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryApiTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +135,7 @@
 		983271D2272752B50010C63A /* DeliveryAppChallengeTests */ = {
 			isa = PBXGroup;
 			children = (
+				B72496F727A0BCF300244D5C /* Service */,
 				983271D3272752B50010C63A /* DeliveryAppChallengeTests.swift */,
 			);
 			path = DeliveryAppChallengeTests;
@@ -180,6 +185,7 @@
 		983271F0272753000010C63A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B72496F527A0AEFC00244D5C /* Address.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -317,6 +323,14 @@
 			path = MenuListView;
 			sourceTree = "<group>";
 		};
+		B72496F727A0BCF300244D5C /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				B72496F827A0BD0B00244D5C /* DeliveryApiTests.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -431,6 +445,7 @@
 				98612707272F56AB0049403C /* SettingsView.swift in Sources */,
 				98F1297D272F51DE00B88A87 /* MenuItemViewController.swift in Sources */,
 				98F12975272F48E400B88A87 /* AddressCellView.swift in Sources */,
+				B72496F627A0AEFC00244D5C /* Address.swift in Sources */,
 				98F12970272F41AE00B88A87 /* RestaurantCellView.swift in Sources */,
 				98F12977272F48F000B88A87 /* AddressListView.swift in Sources */,
 				98EA055E272A0949007B0228 /* RestaurantListViewController.swift in Sources */,
@@ -455,6 +470,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B72496F927A0BD0B00244D5C /* DeliveryApiTests.swift in Sources */,
 				983271D4272752B50010C63A /* DeliveryAppChallengeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+enum ApiResponse: Error {
+    case invalidResponse
+    case requestFailed
+}
+
 struct DeliveryApi {
 
     func fetchRestaurants(_ completion: ([String]) -> Void) {
@@ -14,9 +19,21 @@ struct DeliveryApi {
         completion(["Restaurant 1", "Restaurant 2", "Restaurant 3"])
     }
 
-    func searchAddresses(_ completion: ([String]) -> Void) {
-
-        completion(["Address 1", "Address 2", "Address 3"])
+    func searchAddresses(_ completion: @escaping (Result<[Address], ApiResponse>) -> Void) {
+        guard let url = URL(string: "https://raw.githubusercontent.com/devpass-tech/challenge-delivery-app/main/api/address_search_results.json") else { return }
+        let request = URLRequest(url: url)
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let data = data {
+                if let address = try? JSONDecoder().decode([Address].self, from: data) {
+                    completion(.success(address))
+                } else {
+                    completion(.failure(.invalidResponse))
+                }
+            } else {
+                completion(.failure(.requestFailed))
+            }
+        }
+        task.resume()
     }
 
     func fetchRestaurantDetails(_ completion: (String) -> Void) {

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Service/DeliveryApiTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/Service/DeliveryApiTests.swift
@@ -1,0 +1,41 @@
+//
+//  DeliveryApiTests.swift
+//  DeliveryAppChallengeTests
+//
+//  Created by Rodrigo Lemos on 25/01/22.
+//
+
+import XCTest
+
+@testable import DeliveryAppChallenge
+
+final class DeliveryApiTests: XCTestCase {
+
+    private var sut: DeliveryApi!
+    
+    override func setUpWithError() throws {
+        super.setUp()
+        sut = DeliveryApi()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_whenFetchAddress_shouldReturnValidAddress() {
+        let expectation = expectation(description: "Waiting address to be returned")
+        sut.searchAddresses { result in
+            switch result {
+            case .success(let address):
+                if !address.isEmpty {
+                    XCTAssertNotNil(address)
+                    expectation.fulfill()
+                }
+            default: break
+            }
+        }
+        wait(for: [expectation], timeout: 0.7)
+    }
+
+}


### PR DESCRIPTION
O que mudou?

Implementação da integração com DeliveryAPI consumindo o JSON de endereço.

Porque?

Essa integração conterá todos os endereços possíveis de entrega.

Como?

Criando o model endereço e fazendo a chamada para URL onde tem os endereços. Por fim, testes unitários para validar integração.