### PR TITLE
Criando restaurantDetails request com testes unitários

### DIFF
--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		186785D927A36C420084A695 /* RestaurantDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 186785D827A36C420084A695 /* RestaurantDetailsModel.swift */; };
 		18C4813E27A05509000BF262 /* ServiceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4813D27A05509000BF262 /* ServiceManagerTests.swift */; };
 		18C4814927A0698F000BF262 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814827A0698F000BF262 /* URLProtocolMock.swift */; };
 		18C4814B27A098E7000BF262 /* DeliveryApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		186785D827A36C420084A695 /* RestaurantDetailsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantDetailsModel.swift; sourceTree = "<group>"; };
 		18C4813D27A05509000BF262 /* ServiceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceManagerTests.swift; sourceTree = "<group>"; };
 		18C4814827A0698F000BF262 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
 		18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryApiTests.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */,
+				186785D827A36C420084A695 /* RestaurantDetailsModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				98F12975272F48E400B88A87 /* AddressCellView.swift in Sources */,
 				18DC461C279FA210001911D6 /* Router.swift in Sources */,
 				98F12970272F41AE00B88A87 /* RestaurantCellView.swift in Sources */,
+				186785D927A36C420084A695 /* RestaurantDetailsModel.swift in Sources */,
 				98F12977272F48F000B88A87 /* AddressListView.swift in Sources */,
 				98EA055E272A0949007B0228 /* RestaurantListViewController.swift in Sources */,
 				98F1297B272F51AE00B88A87 /* SettingsViewController.swift in Sources */,

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/RestaurantDetailsModel.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/RestaurantDetailsModel.swift
@@ -1,0 +1,38 @@
+//
+//  RestaurantDetailsModel.swift
+//  DeliveryAppChallenge
+//
+//  Created by Alley Pereira on 27/01/22.
+//
+
+import Foundation
+
+struct RestaurantDetailsModel: Codable {
+
+	let name: String
+	let category: String
+	let deliveryTime: DeliveryTime
+	let reviews: Reviews
+	let menu: Menu
+
+	struct DeliveryTime: Codable {
+		let min: Int
+		let max: Int
+	}
+
+	struct Reviews: Codable {
+		let score: Double
+		let count: Int
+	}
+
+	struct Menu: Codable {
+		let name: String
+		let category: String
+		let price: Double
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case name, category, reviews, menu
+		case deliveryTime = "delivery_time"
+	}
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
@@ -43,10 +43,18 @@ struct DeliveryApi {
         completion(["Address 1", "Address 2", "Address 3"])
     }
 
-    func fetchRestaurantDetails(_ completion: (String) -> Void) {
+	func fetchRestaurantDetails(_ completion: @escaping (RestaurantDetailsModel?) -> Void) {
 
-        completion("Restaurant Details")
-    }
+		serviceManager.get(request: Router.fetchRestaurantDetails.getRequest,
+						   of: RestaurantDetailsModel.self) { result in
+			switch result {
+			case .success(let restaurantDetails):
+				completion(restaurantDetails)
+			case .failure(_):
+				completion(nil)
+			}
+		}
+	}
 
     func fetchMenuItem(_ completion: (String) -> Void) {
 

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
@@ -25,7 +25,7 @@ enum Router {
 		case .fetchRestaurants:
 			return "/home_restaurant_list.json"
 		case .fetchRestaurantDetails:
-			return ""
+			return "/restaurant_details.json"
 		case .fetchMenuItem:
 			return ""
 		}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
@@ -80,7 +80,7 @@ class DeliveryApiTests: XCTestCase {
 		}
 	}
 
-	func test_fetchRestaurantList_aapiManagerReturnNonEmptyList() {
+	func test_fetchRestaurantList_apiManagerReturnNonEmptyList() {
 		// Given
 		let listMock = [RestaurantsListModel(
 			name: "Benjamin a Padaria",

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/DeliveryApiTests.swift
@@ -16,16 +16,19 @@ class DeliveryApiTests: XCTestCase {
 
 	class APIServiceSpy: APIServiceProtocol {
 
-		var session: URLSession = {
-			URLProtocolMock.mockSession(
-				with: Router.fetchRestaurants.getRequest,
-				completionMock: (nil,nil,nil)
-			)
-		}()
+		let session: URLSession
+
+		init(session: URLSession) {
+			self.session = session
+		}
 
 		var getCalled: Bool = false
 
-		func get<T>(request: URLRequest, of type: T.Type, completion: @escaping (Result<T, ServiceError>) -> Void) where T : Decodable {
+		func get<T>(
+			request: URLRequest,
+			of type: T.Type,
+			completion: @escaping (Result<T, ServiceError>) -> Void
+		) where T : Decodable {
 			getCalled = true
 		}
 	}
@@ -43,7 +46,12 @@ class DeliveryApiTests: XCTestCase {
 
 	func test_fetchRestaurants_apiManagerCallsGet() {
 		// Given
-		let spy = APIServiceSpy()
+		let spy = APIServiceSpy(
+			session: URLProtocolMock.mockSession(
+				with: Router.fetchRestaurants.getRequest,
+				completionMock: (nil,nil,nil)
+			)
+		)
 		self.sut.serviceManager = spy
 
 		// When
@@ -54,8 +62,110 @@ class DeliveryApiTests: XCTestCase {
 		}
 	}
 
-	private func encode(_ dataMock: [RestaurantsListModel]) -> Data {
-		try! JSONEncoder().encode(dataMock)
+	func test_fetchRestaurantList_apiManagerSendsNilForRequestEmpty() {
+		// Given
+		let spy = APIServiceSpy(
+			session: URLProtocolMock.mockSession(
+				with: Router.fetchRestaurantDetails.getRequest,
+				completionMock: (nil,nil,ServiceError.emptyData)
+			)
+		)
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurants { list in
+
+			// Then
+			XCTAssert(list.isEmpty)
+		}
 	}
 
+	func test_fetchRestaurantList_aapiManagerReturnNonEmptyList() {
+		// Given
+		let listMock = [RestaurantsListModel(
+			name: "Benjamin a Padaria",
+			category: "Padaria",
+			deliveryTime: .init(min: 10, max: 45)
+		)]
+		let data: Data = try! JSONEncoder().encode(listMock)
+		let spy = APIServiceSpy(
+			session:
+				URLProtocolMock.mockSession(
+					with: Router.fetchRestaurants.getRequest,
+					completionMock: (data, nil, nil)
+				)
+		)
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurants { listArray in
+			// Then
+			listArray.enumerated().forEach { (index, restaurant) in
+				XCTAssertEqual(restaurant.category, listMock[index].category)
+			}
+		}
+	}
+
+	func test_fetchRestaurantDetails_apiManagerCallsGet() {
+		// Given
+		let spy = APIServiceSpy(
+			session: URLProtocolMock.mockSession(
+				with: Router.fetchRestaurantDetails.getRequest,
+				completionMock: (nil,nil,nil)
+			)
+		)
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurantDetails { _ in
+
+		// Then
+			XCTAssertTrue(spy.getCalled)
+
+		}
+	}
+
+	func test_fetchRestaurantDetails_apiManagerSendsNilForRequestError() {
+		// Given
+		let spy = APIServiceSpy(
+			session: URLProtocolMock.mockSession(
+				with: Router.fetchRestaurantDetails.getRequest,
+				completionMock: (nil,nil,ServiceError.decodeError)
+			)
+		)
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurantDetails { details in
+
+			// Then
+			XCTAssertNil(details)
+		}
+	}
+
+	func test_fetchRestaurantDetails_apiManagerReturnNonEmptyDetails() {
+		// Given
+		let detailsMock = RestaurantDetailsModel(
+			name: "Benjamin a Padaria",
+			category: "Padaria",
+			deliveryTime: .init(min: 10, max: 45),
+			reviews: .init(score: 4.6, count: 100),
+			menu: .init(name: "Bolo de Laranja 🍊", category: "Padaria", price: 9.99)
+		)
+
+		let data: Data = try! JSONEncoder().encode(detailsMock)
+		let spy = APIServiceSpy(
+			session: URLProtocolMock.mockSession(
+				with: Router.fetchRestaurantDetails.getRequest,
+				completionMock: (data, nil, nil)
+			)
+		)
+		self.sut.serviceManager = spy
+
+		// When
+		sut.fetchRestaurantDetails { details in
+			// Then
+			XCTAssertEqual(details?.name, detailsMock.name)
+		}
+	}
 }


### PR DESCRIPTION
**O que mudou?**
Implementando a rota de RestaurantDetails com testes unitários.

**Porque?**
O aplicativo precisa receber da API as informações de detalhes de cada restaurante com testes unitários.


**Como?**
Criando um novo método de request na DeliveryAPI.
