### PR TITLE
Feature: Implementar integração com DeliveryAPI para busca de endereços

### DIFF
--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge.xcodeproj/project.pbxproj
@@ -8,10 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		186785D927A36C420084A695 /* RestaurantDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 186785D827A36C420084A695 /* RestaurantDetailsModel.swift */; };
-		9277504D27A081C8005FBCF8 /* DefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277504C27A081C8005FBCF8 /* DefaultsManager.swift */; };
-		9277504F27A081F6005FBCF8 /* DefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277504E27A081F6005FBCF8 /* DefaultsKey.swift */; };
-		9277505127A08218005FBCF8 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277505027A08218005FBCF8 /* UserDefaults.swift */; };
-		9277505327A0826B005FBCF8 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277505227A0826B005FBCF8 /* User.swift */; };
 		18C4813E27A05509000BF262 /* ServiceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4813D27A05509000BF262 /* ServiceManagerTests.swift */; };
 		18C4814927A0698F000BF262 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814827A0698F000BF262 /* URLProtocolMock.swift */; };
 		18C4814B27A098E7000BF262 /* DeliveryApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */; };
@@ -19,6 +15,10 @@
 		18DC4617279F71A4001911D6 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC4616279F71A4001911D6 /* APIService.swift */; };
 		18DC4619279F85D3001911D6 /* RestaurantsListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */; };
 		18DC461C279FA210001911D6 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DC461B279FA210001911D6 /* Router.swift */; };
+		9277504D27A081C8005FBCF8 /* DefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277504C27A081C8005FBCF8 /* DefaultsManager.swift */; };
+		9277504F27A081F6005FBCF8 /* DefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277504E27A081F6005FBCF8 /* DefaultsKey.swift */; };
+		9277505127A08218005FBCF8 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277505027A08218005FBCF8 /* UserDefaults.swift */; };
+		9277505327A0826B005FBCF8 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277505227A0826B005FBCF8 /* User.swift */; };
 		983271BD272752AF0010C63A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271BC272752AF0010C63A /* AppDelegate.swift */; };
 		983271BF272752AF0010C63A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271BE272752AF0010C63A /* SceneDelegate.swift */; };
 		983271C1272752AF0010C63A /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983271C0272752AF0010C63A /* HomeViewController.swift */; };
@@ -46,6 +46,7 @@
 		98FC5AB42732BFC8002412EA /* MenuListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB32732BFC8002412EA /* MenuListView.swift */; };
 		98FC5AB62732BFDA002412EA /* MenuCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB52732BFDA002412EA /* MenuCellView.swift */; };
 		98FC5AB82732C1EF002412EA /* MenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC5AB72732C1EF002412EA /* MenuItemView.swift */; };
+		B75AA24E27A875C200B8D11D /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75AA24D27A875C200B8D11D /* Address.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,10 +61,6 @@
 
 /* Begin PBXFileReference section */
 		186785D827A36C420084A695 /* RestaurantDetailsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantDetailsModel.swift; sourceTree = "<group>"; };
-		9277504C27A081C8005FBCF8 /* DefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsManager.swift; sourceTree = "<group>"; };
-		9277504E27A081F6005FBCF8 /* DefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DefaultsKey.swift; path = DeliveryAppChallenge/Service/DefaultsKey.swift; sourceTree = SOURCE_ROOT; };
-		9277505027A08218005FBCF8 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserDefaults.swift; path = DeliveryAppChallenge/Service/UserDefaults.swift; sourceTree = SOURCE_ROOT; };
-		9277505227A0826B005FBCF8 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = User.swift; path = DeliveryAppChallenge/Service/User.swift; sourceTree = SOURCE_ROOT; };
 		18C4813D27A05509000BF262 /* ServiceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceManagerTests.swift; sourceTree = "<group>"; };
 		18C4814827A0698F000BF262 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
 		18C4814A27A098E7000BF262 /* DeliveryApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryApiTests.swift; sourceTree = "<group>"; };
@@ -71,6 +68,10 @@
 		18DC4616279F71A4001911D6 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestaurantsListModel.swift; path = DeliveryAppChallenge/Models/RestaurantsListModel.swift; sourceTree = SOURCE_ROOT; };
 		18DC461B279FA210001911D6 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		9277504C27A081C8005FBCF8 /* DefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsManager.swift; sourceTree = "<group>"; };
+		9277504E27A081F6005FBCF8 /* DefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DefaultsKey.swift; path = DeliveryAppChallenge/Service/DefaultsKey.swift; sourceTree = SOURCE_ROOT; };
+		9277505027A08218005FBCF8 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserDefaults.swift; path = DeliveryAppChallenge/Service/UserDefaults.swift; sourceTree = SOURCE_ROOT; };
+		9277505227A0826B005FBCF8 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = User.swift; path = DeliveryAppChallenge/Service/User.swift; sourceTree = SOURCE_ROOT; };
 		983271B9272752AF0010C63A /* DeliveryAppChallenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DeliveryAppChallenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		983271BC272752AF0010C63A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		983271BE272752AF0010C63A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -101,6 +102,7 @@
 		98FC5AB32732BFC8002412EA /* MenuListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListView.swift; sourceTree = "<group>"; };
 		98FC5AB52732BFDA002412EA /* MenuCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCellView.swift; sourceTree = "<group>"; };
 		98FC5AB72732C1EF002412EA /* MenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemView.swift; sourceTree = "<group>"; };
+		B75AA24D27A875C200B8D11D /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -223,6 +225,7 @@
 				9277505227A0826B005FBCF8 /* User.swift */,
 				18DC4618279F85D3001911D6 /* RestaurantsListModel.swift */,
 				186785D827A36C420084A695 /* RestaurantDetailsModel.swift */,
+				B75AA24D27A875C200B8D11D /* Address.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				98F12968272F30E500B88A87 /* AddressView.swift in Sources */,
 				983271BF272752AF0010C63A /* SceneDelegate.swift in Sources */,
 				98FC5AB62732BFDA002412EA /* MenuCellView.swift in Sources */,
+				B75AA24E27A875C200B8D11D /* Address.swift in Sources */,
 				983271BD272752AF0010C63A /* AppDelegate.swift in Sources */,
 				98F12968272F30E500B88A87 /* AddressView.swift in Sources */,
 				983271BF272752AF0010C63A /* SceneDelegate.swift in Sources */,

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/Address.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Models/Address.swift
@@ -1,0 +1,15 @@
+//
+//  Address.swift
+//  DeliveryAppChallenge
+//
+//  Created by Rodrigo Lemos on 31/01/22.
+//
+
+import Foundation
+
+struct Address: Codable {
+    
+    let street: String
+    let number: String
+    let neighborhood: String
+}

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/DeliveryApi.swift
@@ -38,9 +38,15 @@ struct DeliveryApi {
 		}
     }
 
-    func searchAddresses(_ completion: ([String]) -> Void) {
-
-        completion(["Address 1", "Address 2", "Address 3"])
+    func searchAddresses(_ completion: @escaping (Result<[Address], ServiceError>) -> Void) {
+        serviceManager.get(request: Router.fetchAddress.getRequest, of: [Address].self) { result in
+            switch result {
+            case .success(let addressList):
+                completion(.success(addressList))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 
 	func fetchRestaurantDetails(_ completion: @escaping (RestaurantDetailsModel?) -> Void) {

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallenge/Service/Router.swift
@@ -13,6 +13,7 @@ enum Router {
 	case fetchRestaurants
 	case fetchRestaurantDetails
 	case fetchMenuItem
+    case fetchAddress
 
 	static private let baseURL: String = "https://raw.githubusercontent.com/devpass-tech/challenge-delivery-app/main/api"
 
@@ -28,6 +29,8 @@ enum Router {
 			return "/restaurant_details.json"
 		case .fetchMenuItem:
 			return ""
+        case .fetchAddress:
+            return "/address_search_results.json"
 		}
 	}
 

--- a/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-1/DeliveryAppChallengeTests/ServiceManagerTests.swift
@@ -176,6 +176,111 @@ class ServiceManagerTests: XCTestCase {
 
 		wait(for: [expectation], timeout: 1)
 	}
+    
+    func test_get_whenFetchAddress_shouldReturnSuccess() {
+        // Given
+        let endpoint = Router.fetchAddress
+        let addressDataMock = addressDataMock()
+        let successCompletion = createResquestCompletionMock(endpoint: endpoint,
+                                                             dataMock: addressDataMock,
+                                                             statusCode: 200,
+                                                             error: nil)
+        
+        let mockSession = URLProtocolMock.mockSession(with: endpoint.getRequest, completionMock: successCompletion)
+        self.sut = APIService(mockSession)
+        let expectation = expectation(description: "Success")
+        
+        // When
+        sut.get(request: endpoint.getRequest, of: [Address].self) { result in
+            // Then
+            switch result {
+            case .failure:
+                XCTFail()
+            case .success(let address):
+                expectation.fulfill()
+                XCTAssertFalse(address.isEmpty)
+                if let address = try? XCTUnwrap(address.first) {
+                    XCTAssertEqual(address.street, addressDataMock[0].street)
+                    XCTAssertEqual(address.number, addressDataMock[0].number)
+                    XCTAssertEqual(address.neighborhood, addressDataMock[0].neighborhood)
+                } else {
+                    XCTFail()
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 0.7)
+    }
+    
+    func test_get_whenFetchAddressEmptyData_shouldReturnFailure() {
+        // Given
+        let endpoint = Router.fetchAddress
+        let successCompletion: URLProtocolMock.RequestCompletion = (nil,nil,nil)
+        let mockSession = URLProtocolMock.mockSession(with: endpoint.getRequest, completionMock: successCompletion)
+        self.sut = APIService(mockSession)
+
+        let expectation = expectation(description: "failure")
+
+        // When
+        sut.get(request: endpoint.getRequest, of: [Address].self) { result in
+            // Then
+            switch result {
+            case .failure(let error):
+                expectation.fulfill()
+                XCTAssertEqual(error.localizedDescription, ServiceError.emptyData.localizedDescription)
+            case .success:
+                XCTFail()
+            }
+        }
+        wait(for: [expectation], timeout: 0.7)
+    }
+    
+    func test_whenErrorFetchAddress_shouldReturnFailure() {
+        // Given
+        let endpoint = Router.fetchAddress
+        let expectedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+        let successCompletion: URLProtocolMock.RequestCompletion = (nil,nil,expectedError)
+        let mockSession = URLProtocolMock.mockSession(with: endpoint.getRequest, completionMock: successCompletion)
+        self.sut = APIService(mockSession)
+
+        let expectation = expectation(description: "failure")
+
+        // When
+        sut.get(request: endpoint.getRequest, of: [Address].self) { result in
+            // Then
+            switch result {
+            case .failure(let error):
+                expectation.fulfill()
+                XCTAssertEqual(error.localizedDescription,
+                               ServiceError.requestFailed(description: expectedError.localizedDescription).localizedDescription)
+            case .success:
+                XCTFail()
+            }
+        }
+        wait(for: [expectation], timeout: 0.7)
+    }
+    
+    func test_get_whenAddressDecodeError_shouldReturnFailure() {
+        // Given
+        let endpoint = Router.fetchAddress
+        let successCompletion: URLProtocolMock.RequestCompletion = ("{\"key\": \"value\"}".data(using: .utf8), nil, nil)
+        let mockSession = URLProtocolMock.mockSession(with: endpoint.getRequest, completionMock: successCompletion)
+        self.sut = APIService(mockSession)
+
+        let expectation = expectation(description: "failure")
+
+        // When
+        sut.get(request: endpoint.getRequest, of: [Address].self) { result in
+            // Then
+            switch result {
+            case .failure(let error):
+                expectation.fulfill()
+                XCTAssertEqual(error.localizedDescription, ServiceError.decodeError.localizedDescription)
+            case .success:
+                XCTFail()
+            }
+        }
+        wait(for: [expectation], timeout: 1)
+    }
 
 
 
@@ -206,5 +311,10 @@ class ServiceManagerTests: XCTestCase {
 		]
 		return dataMock
 	}
+    
+    private func addressDataMock() -> [Address] {
+        let addressDataMock: [Address] = [Address(street: "Rua Augusta", number: "495", neighborhood: "Consolação")]
+        return addressDataMock
+    }
 
 }


### PR DESCRIPTION
O que mudou?

Implementação da integração com DeliveryAPI consumindo o JSON de endereço.

Porque?

Essa integração conterá todos os endereços possíveis de entrega.

Como?

Criando o model endereço e fazendo a chamada para URL onde tem os endereços. Por fim, testes unitários para validar integração.