### PR TITLE
Passa a chamada da ViewModel implementada para a ViewController

### DIFF
--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
@@ -27,11 +27,15 @@ private enum Sections: Int, CaseIterable {
     }
 }
 
+protocol SettingsViewDelegate: AnyObject {
+    func getInfo(key: SettingsViewModel.UserInfoData) -> String
+}
+
 class SettingsView: UIView {
     
     let cellIdentifier = "SettingsCell"
     
-    weak var delegate: SettingsViewControllerDelegate?
+    weak var delegate: SettingsViewDelegate?
     
     lazy var tableView: UITableView = {
         let tableView = UITableView.init(frame: CGRect.zero, style: .grouped)

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
@@ -31,7 +31,7 @@ class SettingsView: UIView {
     
     let cellIdentifier = "SettingsCell"
     
-    private weak var delegate: SettingsViewControllerProtocol?
+    weak var delegate: SettingsViewControllerDelegate?
     
     lazy var tableView: UITableView = {
         let tableView = UITableView.init(frame: CGRect.zero, style: .grouped)
@@ -42,8 +42,7 @@ class SettingsView: UIView {
         return tableView
     }()
     
-    init(delegate: SettingsViewControllerProtocol) {
-        self.delegate = delegate
+    init() {
         super.init(frame: .zero)
         backgroundColor = .white
         
@@ -94,18 +93,17 @@ extension SettingsView: UITableViewDataSource {
         
         switch sectionIndex {
         case .name:
-            cell.textLabel?.text = delegate?.getName()
+            cell.textLabel?.text = delegate?.getInfo(key: .userName)
             
         case .email:
-            cell.textLabel?.text = delegate?.getEmail()
+            cell.textLabel?.text = delegate?.getInfo(key: .userEmail)
             
         case .address:
-            cell.textLabel?.text = delegate?.getAddress()
+            cell.textLabel?.text = delegate?.getInfo(key: .userAddress)
             
         case .paymentMethod:
-            cell.textLabel?.text = delegate?.getPaymentMethod()
+            cell.textLabel?.text = delegate?.getInfo(key: .paymentMethod)
         }
-        
         return cell
     }
     

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsView.swift
@@ -12,7 +12,7 @@ private enum Sections: Int, CaseIterable {
     case email
     case address
     case paymentMethod
-
+    
     var name: String {
         switch self {
         case .name:
@@ -28,10 +28,10 @@ private enum Sections: Int, CaseIterable {
 }
 
 class SettingsView: UIView {
-
+    
     let cellIdentifier = "SettingsCell"
-
-    private let viewModel: SettingsViewModel
+    
+    private weak var delegate: SettingsViewControllerProtocol?
     
     lazy var tableView: UITableView = {
         let tableView = UITableView.init(frame: CGRect.zero, style: .grouped)
@@ -41,15 +41,15 @@ class SettingsView: UIView {
         tableView.dataSource = self
         return tableView
     }()
-
-    init(viewModel: SettingsViewModel = SettingsViewModel()) {
-        self.viewModel = viewModel
+    
+    init(delegate: SettingsViewControllerProtocol) {
+        self.delegate = delegate
         super.init(frame: .zero)
         backgroundColor = .white
         
         addSubviews()
         configureConstraints()
-
+        
         tableView.reloadData()
     }
     @available( *, unavailable)
@@ -59,16 +59,14 @@ class SettingsView: UIView {
 }
 
 extension SettingsView {
-
+    
     func addSubviews() {
-
         addSubview(tableView)
     }
-
+    
     func configureConstraints() {
-
+        
         NSLayoutConstraint.activate([
-
             tableView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
             tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
@@ -78,44 +76,43 @@ extension SettingsView {
 }
 
 extension SettingsView: UITableViewDataSource {
-
+    
     func numberOfSections(in tableView: UITableView) -> Int {
         return Sections.allCases.count
     }
-
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
         return 1
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-
+        
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-
+        
         guard let sectionIndex = Sections(rawValue: indexPath.section)
         else { return UITableViewCell() }
-
+        
         switch sectionIndex {
         case .name:
-            cell.textLabel?.text = viewModel.getInfo(for: .userName)
-
+            cell.textLabel?.text = delegate?.getName()
+            
         case .email:
-            cell.textLabel?.text = viewModel.getInfo(for: .userEmail)
-
+            cell.textLabel?.text = delegate?.getEmail()
+            
         case .address:
-            cell.textLabel?.text = viewModel.getInfo(for: .userAddress)
-
+            cell.textLabel?.text = delegate?.getAddress()
+            
         case .paymentMethod:
-            cell.textLabel?.text = viewModel.getInfo(for: .paymentMethod)
+            cell.textLabel?.text = delegate?.getPaymentMethod()
         }
         
         return cell
     }
-
+    
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-
+        
         guard let section = Sections(rawValue: section) else {
-
+            
             return nil
         }
         return section.name

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 
-protocol SettingsViewControllerDelegate: AnyObject {
-    func getInfo(key: SettingsViewModel.UserInfoData) -> String
-}
-
-class SettingsViewController: UIViewController, SettingsViewControllerDelegate {
+class SettingsViewController: UIViewController, SettingsViewDelegate {
     
     private let viewModel: SettingsViewModel
     

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
@@ -11,13 +11,9 @@ class SettingsViewController: UIViewController {
     
     private let viewModel: SettingsViewModel
     
-    private let settingsView: SettingsView
-    
-    init(viewModel: SettingsViewModel = SettingsViewModel(), settingsView: SettingsView = SettingsView()) {
-        self.settingsView = settingsView
+    init(viewModel: SettingsViewModel = SettingsViewModel()) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        settingsView.delegate = self
         navigationItem.title = "Settings"
     }
     
@@ -26,7 +22,10 @@ class SettingsViewController: UIViewController {
     }
     
     override func loadView() {
+        let settingsView = SettingsView()
+        settingsView.delegate = self
         self.view = settingsView
+
     }
 }
 

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
@@ -7,11 +7,22 @@
 
 import UIKit
 
-class SettingsViewController: UIViewController {
+protocol SettingsViewControllerProtocol: AnyObject {
+    func getName() -> String
+    func getEmail() -> String
+    func getAddress() -> String
+    func getPaymentMethod() -> String
+    
+}
 
-    init() {
+
+class SettingsViewController: UIViewController, SettingsViewControllerProtocol {
+
+    private let viewModel: SettingsViewModel
+    
+    init(viewModel: SettingsViewModel = SettingsViewModel()) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-
         navigationItem.title = "Settings"
     }
     
@@ -20,6 +31,23 @@ class SettingsViewController: UIViewController {
     }
     
     override func loadView() {
-        self.view = SettingsView()
+        self.view = SettingsView(delegate: self)
     }
+    
+    func getName() -> String {
+        return viewModel.getInfo(for: .userName)
+    }
+    
+    func getEmail() -> String {
+        return viewModel.getInfo(for: .userEmail)
+    }
+    
+    func getAddress() -> String {
+        return viewModel.getInfo(for: .userAddress)
+    }
+    
+    func getPaymentMethod() -> String {
+        return viewModel.getInfo(for: .paymentMethod)
+    }
+
 }

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SettingsViewController: UIViewController, SettingsViewDelegate {
+class SettingsViewController: UIViewController {
     
     private let viewModel: SettingsViewModel
     
@@ -28,7 +28,9 @@ class SettingsViewController: UIViewController, SettingsViewDelegate {
     override func loadView() {
         self.view = settingsView
     }
-    
+}
+
+extension SettingsViewController: SettingsViewDelegate {
     func getInfo(key: SettingsViewModel.UserInfoData) -> String {
         return  viewModel.getInfo(for: key)
     }

--- a/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-matheus-reis-2/DeliveryAppChallenge/Screens/Settings/SettingsViewController.swift
@@ -7,22 +7,21 @@
 
 import UIKit
 
-protocol SettingsViewControllerProtocol: AnyObject {
-    func getName() -> String
-    func getEmail() -> String
-    func getAddress() -> String
-    func getPaymentMethod() -> String
-    
+protocol SettingsViewControllerDelegate: AnyObject {
+    func getInfo(key: SettingsViewModel.UserInfoData) -> String
 }
 
-
-class SettingsViewController: UIViewController, SettingsViewControllerProtocol {
-
+class SettingsViewController: UIViewController, SettingsViewControllerDelegate {
+    
     private let viewModel: SettingsViewModel
     
-    init(viewModel: SettingsViewModel = SettingsViewModel()) {
+    private let settingsView: SettingsView
+    
+    init(viewModel: SettingsViewModel = SettingsViewModel(), settingsView: SettingsView = SettingsView()) {
+        self.settingsView = settingsView
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        settingsView.delegate = self
         navigationItem.title = "Settings"
     }
     
@@ -31,23 +30,10 @@ class SettingsViewController: UIViewController, SettingsViewControllerProtocol {
     }
     
     override func loadView() {
-        self.view = SettingsView(delegate: self)
+        self.view = settingsView
     }
     
-    func getName() -> String {
-        return viewModel.getInfo(for: .userName)
+    func getInfo(key: SettingsViewModel.UserInfoData) -> String {
+        return  viewModel.getInfo(for: key)
     }
-    
-    func getEmail() -> String {
-        return viewModel.getInfo(for: .userEmail)
-    }
-    
-    func getAddress() -> String {
-        return viewModel.getInfo(for: .userAddress)
-    }
-    
-    func getPaymentMethod() -> String {
-        return viewModel.getInfo(for: .paymentMethod)
-    }
-
 }


### PR DESCRIPTION
Descrição simples da nova feature
✨ implementa corretamente a ViewModel na Controller.
Altera a inicialização da viewModel da View para a ViewController e faz as alterações necessárias.
Criado um delegate na controller para o recebimento dos dados na view.
Nome da função delegate agora está correto.

Checklist:
[x] Não adiciona código duplicado
[x] Não contém código comentado
[x] Não contém código WIP